### PR TITLE
add live examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ const md = require('markdown-it')
   .use(require('markdown-it-anchor'), opts)
 ```
 
+[demo as jsfiddle](https://jsfiddle.net/arve0/6x8x5j75/2/)
+
 The `opts` object can contain:
 
 Name              | Description                               | Default

--- a/demo.js
+++ b/demo.js
@@ -1,0 +1,22 @@
+const md = require('markdown-it')();
+const anchor = require('markdown-it-anchor');
+
+md.use(anchor, {
+  // options, here defaults
+	level: 1,
+//  slugify: customSlugify,
+  permalink: false,
+//  renderPermalink: customPermalinkRender,
+  permalinkClass: 'header-anchor',
+  permalinkSymbol: '¶',
+  permalinkBefore: false
+});
+
+const src = `# first header
+lorem ipsum
+
+## next section!
+this is totaly awesome`;
+
+// render
+md.render(src);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "files": [
     "README.md",
     "UNLICENSE",
-    "index.js"
+    "index.js",
+    "demo.js"
   ],
   "repository": {
     "type": "git",
@@ -46,5 +47,6 @@
       "transform-object-assign",
       "add-module-exports"
     ]
-  }
+  },
+  "tonicExampleFilename": "demo.js"
 }


### PR DESCRIPTION
Hi!
I made examples [for](https://github.com/arve0/markdown-it-attrs) [my](https://github.com/arve0/markdown-it-header-sections) [plugins](https://github.com/arve0/markdown-it-implicit-figures), was in a good mood and had a local copy of markdown-it-anchor, so I added examples for you too. :octocat: 