### PR TITLE
Add a callback option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,16 @@ See a [demo as JSFiddle](https://jsfiddle.net/9ukc8dy6/).
 
 The `opts` object can contain:
 
-Name              | Description                               | Default
-------------------|-------------------------------------------|------------------------------------
-`level`           | Minimum level to apply anchors on.        | 1
-`slugify`         | A custom slugification function.          | [string.js' `slugify`][slugify]
-`permalink`       | Whether to add permalinks next to titles. | `false`
-`renderPermalink` | A custom permalink rendering function.    | See [`index.es6.js`](index.es6.js)
-`permalinkClass`  | The class of the permalink anchor.        | `header-anchor`
-`permalinkSymbol` | The symbol in the permalink anchor.       | `¶`
-`permalinkBefore` | Place the permalink before the title.     | `false`
+Name              | Description                                 | Default
+------------------|---------------------------------------------|------------------------------------
+`level`           | Minimum level to apply anchors on.          | 1
+`slugify`         | A custom slugification function.            | [string.js' `slugify`][slugify]
+`permalink`       | Whether to add permalinks next to titles.   | `false`
+`renderPermalink` | A custom permalink rendering function.      | See [`index.es6.js`](index.es6.js)
+`permalinkClass`  | The class of the permalink anchor.          | `header-anchor`
+`permalinkSymbol` | The symbol in the permalink anchor.         | `¶`
+`permalinkBefore` | Place the permalink before the title.       | `false`
+`callback`        | Called with token and info after rendering. | `undefined`
 
 [slugify]: http://stringjs.com/#methods/slugify
 
@@ -38,3 +39,5 @@ the header itself.
 
 You may want to use the [link symbol](http://graphemica.com/🔗) as
 `permalinkSymbol`, or a symbol from your favorite web font.
+
+The `callback` option is a function that will be called at the end of rendering with the `token` and an `info` object.  The `info` object has `title` and `slug` properties with the token content and the slug used for the identifier.

--- a/index.es6.js
+++ b/index.es6.js
@@ -65,6 +65,10 @@ const anchor = (md, opts) => {
         if (opts.permalink) {
           opts.renderPermalink(slug, opts, state, tokens.indexOf(token))
         }
+
+        if (opts.callback) {
+          opts.callback(token, {slug, title})
+        }
       })
   })
 

--- a/test.js
+++ b/test.js
@@ -46,3 +46,16 @@ equal(
   md().use(anchor, { level: 2, permalink: true }).render('# H1\n\n## H2'),
   '<h1>H1</h1>\n<h2 id="h2">H2 <a class="header-anchor" href="#h2" aria-hidden="true">¶</a></h2>\n'
 )
+
+const calls = []
+equal(
+  md().use(anchor, { callback: (token, info) => { calls.push({ token, info }) } }).render('# First Heading\n\n## Second Heading'),
+  '<h1 id="first-heading">First Heading</h1>\n<h2 id="second-heading">Second Heading</h2>\n'
+)
+equal(calls.length, 2)
+equal(calls[0].token.tag, 'h1')
+equal(calls[0].info.title, 'First Heading')
+equal(calls[0].info.slug, 'first-heading')
+equal(calls[1].token.tag, 'h2')
+equal(calls[1].info.title, 'Second Heading')
+equal(calls[1].info.slug, 'second-heading')


### PR DESCRIPTION
This adds a `callback` option that can be provided to get information about the modified heading tokens.  The callback is called with `token` and `info` arguments.  The `info` object has `title` and `slug` properties as generated by the plugin.

Fixes #15.