### PR TITLE
Use existing id as slug if present

### DIFF
--- a/index.es6.js
+++ b/index.es6.js
@@ -63,9 +63,12 @@ const anchor = (md, opts) => {
           .filter(token => token.type === 'text')
           .reduce((acc, t) => acc + t.content, '')
 
-        const slug = uniqueSlug(opts.slugify(title), slugs)
+        let slug = token.attrGet('id')
 
-        token.attrPush(['id', slug])
+        if (slug == null) {
+          slug = uniqueSlug(opts.slugify(title), slugs)
+          token.attrPush(['id', slug])
+        }
 
         if (opts.permalink) {
           opts.renderPermalink(slug, opts, state, tokens.indexOf(token))

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-plugin-transform-object-assign": "^6.1.18",
     "babel-preset-es2015": "^6.1.18",
     "markdown-it": "^6.0.0",
+    "markdown-it-attrs": "^0.8.0",
     "standard": "^4.0.1"
   },
   "babel": {

--- a/test.js
+++ b/test.js
@@ -1,10 +1,16 @@
 import { equal } from 'assert'
 import md from 'markdown-it'
+import attrs from 'markdown-it-attrs'
 import anchor from './'
 
 equal(
   md().use(anchor).render('# H1\n\n## H2'),
   '<h1 id="h1">H1</h1>\n<h2 id="h2">H2</h2>\n'
+)
+
+equal(
+  md().use(attrs, anchor).render('# H1 {id=bubblegum}\n\n## H2 {id=shoelaces}'),
+  '<h1 id="bubblegum">H1</h1>\n<h2 id="shoelaces">H2</h2>\n'
 )
 
 equal(


### PR DESCRIPTION
Instead of always generating a slug, use an existing one if the token already has an "id" attribute.

This allows users to use slugs by setting the `id` of the token with something like [`markdown-it-attrs`](https://github.com/arve0/markdown-it-attrs).