### PR TITLE
execute callback once

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ const anchor = (md, opts) => {
   md.core.ruler.push('anchor', state => {
     const slugs = {}
     const tokens = state.tokens
+    const extractHeaders = []
 
     const isLevelSelected = Array.isArray(opts.level)
       ? isLevelSelectedArray(opts.level)
@@ -72,10 +73,10 @@ const anchor = (md, opts) => {
           opts.renderPermalink(slug, opts, state, tokens.indexOf(token))
         }
 
-        if (opts.callback) {
-          opts.callback(token, { slug, title })
-        }
+        extractHeaders.push({ token, slug: { slug, title } })
       })
+      
+      opts.callback && opts.callback(extractHeaders)
   })
 }
 


### PR DESCRIPTION
I think it's not necessary to callback every single header every time. Why don't we just put them together and return at the end?