### PR TITLE
Keep inline html tags in the headings

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ const anchor = (md, opts) => {
       .forEach(token => {
         // Aggregate the next token children text.
         const title = tokens[tokens.indexOf(token) + 1].children
-          .filter(token => token.type === 'text' || token.type === 'code_inline')
+          .filter(token => token.type === 'text' || token.type === 'code_inline' || token.type === 'html_inline')
           .reduce((acc, t) => acc + t.content, '')
 
         let slug = token.attrGet('id')


### PR DESCRIPTION
Currently one of my project that is using markdown-it-anchor [requires keeping HTML tags in the callback info](https://github.com/Manvel/cmints/issues/44). 

Ex.:
```md
## What is <fix>CMintS</fix>?
```

Callback
```js
  const md = require('markdown-it')()
  .use(require('markdown-it-anchor'), {
    callback: (token, info)
    {
      info.title;
    };
  });
```
`info.title;` outputs `What is CMintS?`, while was expected `What is <fix>CMintS</fix>?`.

Please let me know if there is/was a reason why `html_inline` wasn't considered, but `code_inline` was and whether current change makes sense for you and can be added into the repo.

Thanks in advance and thanks for the plugin.