### PR TITLE
Support optional spacing between the header text and the permalink anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Name              | Description                                                 
 `permalink`       | Whether to add permalinks next to titles.                      | `false`
 `renderPermalink` | A custom permalink rendering function.                         | See [`index.js`](index.js)
 `permalinkClass`  | The class of the permalink anchor.                             | `header-anchor`
+`permalinkSpace`  | Place space between the header text and the permalink anchor.  | `true`
 `permalinkSymbol` | The symbol in the permalink anchor.                            | `¶`
 `permalinkBefore` | Place the permalink before the title.                          | `false`
 `permalinkHref`   | A custom permalink `href` rendering function.                  | See [`index.js`](index.js)
@@ -90,4 +91,4 @@ const anchor = require('markdown-it-anchor', {
 
 Looking for an automatic table of contents (TOC) generator? Take a look at
 [markdown-it-toc-done-right](https://www.npmjs.com/package/markdown-it-toc-done-right) it's
-made from the ground to be a great companion of this plugin. 
+made from the ground to be a great companion of this plugin.

--- a/index.js
+++ b/index.js
@@ -26,7 +26,9 @@ const renderPermalink = (slug, opts, state, idx) => {
 
   // `push` or `unshift` according to position option.
   // Space is at the opposite side.
-  linkTokens[position[!opts.permalinkBefore]](space())
+  if (opts.permalinkSpace) {
+    linkTokens[position[!opts.permalinkBefore]](space())
+  }
   state.tokens[idx + 1].children[position[opts.permalinkBefore]](...linkTokens)
 }
 
@@ -85,6 +87,7 @@ anchor.defaults = {
   permalink: false,
   renderPermalink,
   permalinkClass: 'header-anchor',
+  permalinkSpace: true,
   permalinkSymbol: '¶',
   permalinkBefore: false,
   permalinkHref

--- a/test.js
+++ b/test.js
@@ -91,3 +91,13 @@ equal(calls[0].info.slug, 'first-heading')
 equal(calls[1].token.tag, 'h2')
 equal(calls[1].info.title, 'Second Heading')
 equal(calls[1].info.slug, 'second-heading')
+
+equal(
+  md({ html: true }).use(anchor, { permalink: true, permalinkSpace: false }).render('# H1'),
+  '<h1 id="h1">H1<a class="header-anchor" href="#h1" aria-hidden="true">¶</a></h1>\n'
+)
+
+equal(
+  md({ html: true }).use(anchor, { permalink: false, permalinkSpace: false }).render('# H1'),
+  '<h1 id="h1">H1</h1>\n'
+)


### PR DESCRIPTION
* includes testing

### Discussion

The added space between the header text and permalink anchor can throw off CSS alignment, especially when positioning the permalink in front of the header. This commit adds an option which can suppress that added space.

I hope it's useful enough to be merged into your mainline and up to "npm".

I'm happy to make revisions if you see that need.
