### PR TITLE
Support arbitrary permalink attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Name              | Description                                                 
 `permalinkSymbol` | The symbol in the permalink anchor.                            | `¶`
 `permalinkBefore` | Place the permalink before the title.                          | `false`
 `permalinkHref`   | A custom permalink `href` rendering function.                  | See [`index.js`](index.js)
+`permalinkAttrs`  | A custom permalink attributes rendering function.              | See [`index.js`](index.js)
 `callback`        | Called with token and info after rendering.                    | `undefined`
-`permalinkAttrs`  | A function to set arbitrary HTML attributes on the permalink anchor. Called with `slug` and `state`, returns an object of attributes | `() => ({})`
 
 The `renderPermalink` function takes the slug, an options object with
 the above options, and then all the usual markdown-it rendering

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Name              | Description                                                 
 `permalinkBefore` | Place the permalink before the title.                          | `false`
 `permalinkHref`   | A custom permalink `href` rendering function.                  | See [`index.js`](index.js)
 `callback`        | Called with token and info after rendering.                    | `undefined`
+`permalinkAttrs`  | An object of HTML attributes to be set on the permalink anchor | `{}`
 
 The `renderPermalink` function takes the slug, an options object with
 the above options, and then all the usual markdown-it rendering

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Name              | Description                                                 
 `permalinkBefore` | Place the permalink before the title.                          | `false`
 `permalinkHref`   | A custom permalink `href` rendering function.                  | See [`index.js`](index.js)
 `callback`        | Called with token and info after rendering.                    | `undefined`
-`permalinkAttrs`  | An object of HTML attributes to be set on the permalink anchor | `{}`
+`permalinkAttrs`  | A function to set arbitrary HTML attributes on the permalink anchor. Called with `slug` and `state`, returns an object of attributes | `() => ({})`
 
 The `renderPermalink` function takes the slug, an options object with
 the above options, and then all the usual markdown-it rendering

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const renderPermalink = (slug, opts, state, idx) => {
       attrs: [
         ['class', opts.permalinkClass],
         ['href', opts.permalinkHref(slug, state)],
-        ...Object.entries(opts.permalinkAttrs)
+        ...Object.entries(opts.permalinkAttrs(slug, state))
       ]
     }),
     Object.assign(new state.Token('html_block', '', 0), { content: opts.permalinkSymbol }),
@@ -92,7 +92,7 @@ anchor.defaults = {
   permalinkSymbol: '¶',
   permalinkBefore: false,
   permalinkHref,
-  permalinkAttrs: {}
+  permalinkAttrs: () => ({})
 }
 
 export default anchor

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const position = {
 const hasProp = Object.prototype.hasOwnProperty
 
 const permalinkHref = slug => `#${slug}`
+const permalinkAttrs = slug => ({})
 
 const renderPermalink = (slug, opts, state, idx) => {
   const space = () => Object.assign(new state.Token('text', '', 0), { content: ' ' })
@@ -92,7 +93,7 @@ anchor.defaults = {
   permalinkSymbol: '¶',
   permalinkBefore: false,
   permalinkHref,
-  permalinkAttrs: () => ({})
+  permalinkAttrs
 }
 
 export default anchor

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ const renderPermalink = (slug, opts, state, idx) => {
     Object.assign(new state.Token('link_open', 'a', 1), {
       attrs: [
         ['class', opts.permalinkClass],
-        ['href', opts.permalinkHref(slug, state)]
+        ['href', opts.permalinkHref(slug, state)],
+        ...Object.entries(opts.permalinkAttrs)
       ]
     }),
     Object.assign(new state.Token('html_block', '', 0), { content: opts.permalinkSymbol }),
@@ -90,7 +91,8 @@ anchor.defaults = {
   permalinkSpace: true,
   permalinkSymbol: '¶',
   permalinkBefore: false,
-  permalinkHref
+  permalinkHref,
+  permalinkAttrs: {}
 }
 
 export default anchor

--- a/test.js
+++ b/test.js
@@ -104,7 +104,7 @@ equal(
 
 equal(
   md()
-    .use(anchor, { permalink: true, permalinkAttrs: { "aria-label": "permalink", title: "permalink" } })
-    .render("# H1"),
-  '<h1 id="h1">H1 <a class="header-anchor" href="#h1" aria-label="permalink" title="permalink">¶</a></h1>\n'
+    .use(anchor, { permalink: true, permalinkAttrs: (slug, state) => ({ "aria-label": `permalink to ${slug}`, title: "permalink" }) })
+    .render("# My title"),
+  '<h1 id="my-title">My title <a class="header-anchor" href="#my-title" aria-label="permalink to my-title" title="permalink">¶</a></h1>\n'
 );

--- a/test.js
+++ b/test.js
@@ -101,3 +101,10 @@ equal(
   md({ html: true }).use(anchor, { permalink: false, permalinkSpace: false }).render('# H1'),
   '<h1 id="h1">H1</h1>\n'
 )
+
+equal(
+  md()
+    .use(anchor, { permalink: true, permalinkAttrs: { "aria-label": "permalink", title: "permalink" } })
+    .render("# H1"),
+  '<h1 id="h1">H1 <a class="header-anchor" href="#h1" aria-label="permalink" title="permalink">¶</a></h1>\n'
+);


### PR DESCRIPTION
As discussed in #62, it would be nice to give the user the ability to set extra HTML attributes on the permalink anchor.

- [x] Adds a `permalinkAttrs` object to `opts` that sets all key/value pairs at attributes
- [x] Tests
- [x] Docs