### PR TITLE
Fix bugs in  testcode and plugin itself when some IDs (~= slugs) have been defined elsewhere. Existing test case failed to detect this.

### DIFF
--- a/test.js
+++ b/test.js
@@ -9,7 +9,7 @@ equal(
 )
 
 equal(
-  md().use(attrs, anchor).render('# H1 {id=bubblegum}\n\n## H2 {id=shoelaces}'),
+  md().use(attrs).use(anchor).render('# H1 {id=bubblegum}\n\n## H2 {id=shoelaces}'),
   '<h1 id="bubblegum">H1</h1>\n<h2 id="shoelaces">H2</h2>\n'
 )
 
@@ -107,4 +107,31 @@ equal(
     .use(anchor, { permalink: true, permalinkAttrs: (slug, state) => ({ "aria-label": `permalink to ${slug}`, title: "permalink" }) })
     .render("# My title"),
   '<h1 id="my-title">My title <a class="header-anchor" href="#my-title" aria-label="permalink to my-title" title="permalink">¶</a></h1>\n'
+);
+
+equal(
+  (() => {
+    try {
+      return md().use(attrs).use(anchor).render('# H1 {id=bubblegum}\n\n## H2 {id=bubblegum}');
+    } catch (ex) {
+      return ex.message;
+    }
+  })(),
+  "Defined slug/ID 'bubblegum' is not unique. Please fix this ID duplication."
+);
+
+equal(
+  md().use(attrs).use(anchor).render('# H1 {id=h2}\n\n## H2'),
+  '<h1 id="h2">H1</h1>\n<h2 id="h2-2">H2</h2>\n'
+);
+
+equal(
+  (() => {
+    try {
+      return md().use(attrs).use(anchor).render('# H1\n\n## H2 {id=h1}');
+    } catch (ex) {
+      return ex.message;
+    }
+  })(),
+  "Defined slug/ID 'h1' is not unique. Please fix this ID duplication."
 );


### PR DESCRIPTION
(Cherrypicked from SHA-1: a884cf74f2d110e635c91164735854b97a1a0db2)

- fix bug in test code where anchor plugin was not loaded properly together with the attrs plugin

  `.use(attrs, anchor)` --> second arg is for plugin options. Write as `.use(attrs).use(anchor)`
 
- fix bug in plugin where AttrPush() would inject a *second* `id` attribute into a render node where one already existed: the code now always ensures there will be a single `id` per render node by using `AttrSet()` API
- fix bug: when the header ID has already been defined elsewhere, make sure to register it in the unique set of IDs, so we do NOT generate a duplicate ID afterwards.
  See this test case:

  ```
  equal(
    md().use(attrs).use(anchor).render('# H1 {id=h2}\n\n## H2'),
    '<h1 id="h2">H1</h1>\n<h2 id="h2-2">H2</h2>\n'
  );
  ```

  Note the `id=h2` in the input string there.
- feature/bug fix: when we detect an externally defined ID to be a duplicate, throw an error. (HTML node IDs MUST be unique; this will help to ascertain no erroneous duplicate IDs are output by markdown-it+anchor)

  This accounts for scenarios similar to this test case:

  ```
  equal(
    (() => {
      try {
        return md().use(attrs).use(anchor).render('# H1\n\n## H2 {id=h1}');
      } catch (ex) {
        return ex.message;
      }
    })(),
    "Defined slug/ID 'h1' is not unique. Please fix this ID duplication."
  );
  ```

  Note the `id=h1` in the input there.
