### PR TITLE
update default slugify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const slugify = (s) => encodeURIComponent(String(s).trim().toLowerCase().replace(/\s+/g, '-'))
+const slugify = (s) => String(latinize(s.toLowerCase().replace(/[^a-zA-Z0-9 ]+/g, ""))).split(" ").join("-")
 
 const position = {
   false: 'push',


### PR DESCRIPTION
old slugify will slugify not expect character like: 
"a single HTTP/S server"  =>>>  "a-single-http%2Fs-server"
we can't use this id in html.