### PR TITLE
Change markdown-it dependency to `*` and add types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3369,9 +3369,9 @@
       "dev": true
     },
     "linkify-it": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==",
       "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
@@ -3487,22 +3487,28 @@
       }
     },
     "markdown-it": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.0.3.tgz",
+      "integrity": "sha512-M57RsMv+QQmJHz1yCu0gTJRMx/LlxRPtrrw+2kb/CpDVK/graCmWO0qfNnz/SE1FCNdyq3pkMMZ+itTnyT/YGA==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "entities": "~2.0.0",
-        "linkify-it": "^2.0.0",
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
       },
       "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
         "entities": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-anchor",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "markdown-it-anchor",
-  "version": "6.0.1",
+  "name": "@mrdrogdrog/markdown-it-anchor",
+  "version": "6.0.3",
   "description": "Header anchors for markdown-it.",
   "source": "index.js",
   "main": "dist/markdownItAnchor.js",
@@ -9,6 +9,7 @@
   "mangle": {
     "regex": "^_"
   },
+  "types": "./types/index.d.ts",
   "keywords": [
     "markdown",
     "markdown-it",
@@ -22,7 +23,8 @@
     "README.md",
     "UNLICENSE",
     "dist/*",
-    "runkit.js"
+    "runkit.js",
+    "types/*"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "runkitExampleFilename": "runkit.js",
   "dependencies": {},
   "devDependencies": {
-    "markdown-it": "^10.0.0",
+    "markdown-it": "^12.0.0",
     "markdown-it-attrs": "^3.0.1",
     "microbundle": "^0.12.0",
     "standard": "^14.3.1"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "runkitExampleFilename": "runkit.js",
   "dependencies": {},
   "devDependencies": {
-    "markdown-it": "^12.0.0",
+    "markdown-it": "*",
     "markdown-it-attrs": "^3.0.1",
     "microbundle": "^0.12.0",
     "standard": "^14.3.1"

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,26 @@
+import MarkdownIt = require('markdown-it');
+import Core = require('markdown-it/lib/parser_core');
+import Token = require('markdown-it/lib/token');
+
+declare namespace anchor {
+    interface AnchorInfo {
+        slug: string;
+        title: string;
+    }
+
+    interface AnchorOptions {
+        level?: number;
+        slugify?(str: string): string;
+        permalink?: boolean;
+        renderPermalink?(slug: string, opts: AnchorOptions, state: Core, idx: number): void;
+        permalinkClass?: string;
+        permalinkSymbol?: string;
+        permalinkBefore?: boolean;
+        permalinkHref?(slug: string): string;
+        callback?(token: Token, anchor_info: AnchorInfo): void;
+    }
+}
+
+declare function anchor(md: MarkdownIt, opts: anchor.AnchorOptions): void;
+
+export = anchor;


### PR DESCRIPTION
Hi,

I'm one of the devs from https://github.com/hedgedoc/react-client. We use your package, but are having some problems, because this package still depends on markdown-it v10. It confused our typescript setup because it tries to resolve  the v10 types, but we use markdown-it v12 (which is the current version of markdown it.)

Therefore this PR bumps the markdown-it dependency to `*` (because it's only needed for tests). 

Please merge it soon and release a new version :) 

EDIT:
I also added the typescript types from @types/markdown-it-anchor