### PR TITLE
Fix level selection logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ const uniqueSlug = (slug, slugs, failOnNonUnique, startIndex) => {
   return uniq
 }
 
-const isLevelSelectedNumber = selection => level => level >= selection
+const isLevelSelectedNumber = selection => level => level <= selection
 const isLevelSelectedArray = selection => level => selection.includes(level)
 
 const anchor = (md, opts) => {


### PR DESCRIPTION
When I read the docs on the `level` option:
> Minimum level to apply anchors

I assumed, if I set `level: 3` then h1, h2 & h3 will get anchored. Current behaviour however is h3, h4, h5 & h6 get anchors.

I think the confusion stems from higher heading = lower number (h1) and lower header = higher number (h6). It also doesn't make sense to set anchors on h3 through h6 and not on h1 and h2.

This bug was introduced in [this commit](https://github.com/valeriangalliat/markdown-it-anchor/commit/2c97dd4384727af3b74a3e18380c5ab20bc6c991) from 4 years ago. Before that, the logic was in fact `selection >= level` instead of what is now: `level >= selection`. This PR fixes the bug by reversing the math operand: `level <= selection`.