### PR TITLE
Add types that match release 8.0.0

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,27 +1,56 @@
-import MarkdownIt = require('markdown-it');
-import Core = require('markdown-it/lib/parser_core');
-import Token = require('markdown-it/lib/token');
+import MarkdownIt from 'markdown-it';
+import Token from 'markdown-it/lib/token';
+import State from 'markdown-it/lib/rules_core/state_core';
 
 declare namespace anchor {
-    interface AnchorInfo {
-        slug: string;
-        title: string;
-    }
+  export type RenderHref = (slug: string, state: State) => string;
+  export type RenderAttrs = (slug: string, state: State) => Record<string, string | number>;
 
-    interface AnchorOptions {
-        level?: number;
-        slugify?(str: string): string;
-        uniqueSlugStartIndex?: number;
-        permalink?: boolean;
-        renderPermalink?(slug: string, opts: AnchorOptions, state: Core, idx: number): void;
-        permalinkClass?: string;
-        permalinkSpace?: boolean;
-        permalinkSymbol?: string;
-        permalinkBefore?: boolean;
-        permalinkHref?(slug: string, state: Core): string;
-        permalinkAttrs?(slug: string, state: Core): Record<string, string>;
-        callback?(token: Token, anchor_info: AnchorInfo): void;
-    }
+  export interface PermalinkOptions {
+    class?: string,
+    symbol?: string,
+    renderHref?: RenderHref,
+    renderAttrs?: RenderAttrs
+  }
+
+  export interface LinkAfterHeaderPermalinkOptions extends PermalinkOptions {
+    style?: 'visually-hidden' | 'aria-label' | 'aria-describedby' | 'aria-labelledby',
+    assistiveText?: (title: string) => string,
+    visuallyHiddenClass?: string,
+    space?: boolean,
+    placement?: 'before' | 'after'
+  }
+
+  export interface AriaHiddenPermalinkOptions extends PermalinkOptions {
+    space?: boolean,
+    placement?: 'before' | 'after'
+  }
+
+  export type PermalinkGenerator = (slug: string, opts: PermalinkOptions, state: State, index: number) => string;
+
+  export interface AnchorInfo {
+    slug: string;
+    title: string;
+  }
+
+  export interface AnchorOptions {
+    level?: number;
+
+    slugify?(str: string): string;
+
+    uniqueSlugStartIndex?: number;
+    permalink?: PermalinkGenerator;
+
+    callback?(token: Token, anchor_info: AnchorInfo): void;
+
+    tabIndex?: number;
+  }
+
+  export const permalink: {
+    headerLink: () => PermalinkGenerator
+    linkAfterHeader: (opts: LinkAfterHeaderPermalinkOptions) => PermalinkGenerator
+    ariaHidden: (opts: AriaHiddenPermalinkOptions) => PermalinkGenerator
+  };
 }
 
 declare function anchor(md: MarkdownIt, opts?: anchor.AnchorOptions): void;


### PR DESCRIPTION
This PR updates the typescript types so they match the new option structure that was introduced with release 8.0.0

Fixes #94 

Please also create a new release when this is merged. :heart: 