### PR TITLE
fix: fix types of level option

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -34,7 +34,7 @@ declare namespace anchor {
   }
 
   export interface AnchorOptions {
-    level?: number;
+    level?: number | number[];
 
     slugify?(str: string): string;
 


### PR DESCRIPTION
`level` could accept an array of number