### PR TITLE
fix: add `false` type to tabIndex option

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -43,7 +43,7 @@ declare namespace anchor {
 
     callback?(token: Token, anchor_info: AnchorInfo): void;
 
-    tabIndex?: number;
+    tabIndex?: number | false;
   }
 
   export const permalink: {


### PR DESCRIPTION
Thank you for maintaining markdown-it-anchor.

This PR resolve the type warning for `tabIndex: false` .

![スクリーンショット 2021-08-04 10 35 42](https://user-images.githubusercontent.com/34590683/128107953-87df1f9f-5c87-42d3-a064-ffb1557cad01.png)

I believe `false` is valid value as referred in README

> Value of the tabindex attribute on headings, set to `false` to disable.

