### PR TITLE
Fix incorrect type-declaration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "version": "8.3.0",
       "license": "Unlicense",
+      "dependencies": {
+        "@types/markdown-it": "^12.2.1"
+      },
       "devDependencies": {
         "ava": "^3.15.0",
         "markdown-it": "*",
@@ -1277,6 +1280,26 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA=="
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.1.tgz",
+      "integrity": "sha512-iij+ilRX/vxtUPCREjn74xzHo/RorHJDwOsJ6X+TgKw7zSvazhVXnDfwlTnyLOMdiVUjtRYU4CrcUZ7Aci4PmQ==",
+      "dependencies": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*",
+        "highlight.js": "^10.7.2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
     },
     "node_modules/@types/node": {
       "version": "13.13.5",
@@ -4702,6 +4725,14 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "dev": true
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/hosted-git-info": {
       "version": "2.8.5",
@@ -11879,6 +11910,26 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "@types/linkify-it": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA=="
+    },
+    "@types/markdown-it": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.1.tgz",
+      "integrity": "sha512-iij+ilRX/vxtUPCREjn74xzHo/RorHJDwOsJ6X+TgKw7zSvazhVXnDfwlTnyLOMdiVUjtRYU4CrcUZ7Aci4PmQ==",
+      "requires": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*",
+        "highlight.js": "^10.7.2"
+      }
+    },
+    "@types/mdurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
+    },
     "@types/node": {
       "version": "13.13.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
@@ -14623,6 +14674,11 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "dev": true
+    },
+    "highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
     },
     "hosted-git-info": {
       "version": "2.8.5",

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
   },
   "peerDependencies": {
     "markdown-it": "*"
+  },
+  "dependencies": {
+    "@types/markdown-it": "^12.2.1"
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
-import MarkdownIt from 'markdown-it';
-import Token from 'markdown-it/lib/token';
-import State from 'markdown-it/lib/rules_core/state_core';
+import MarkdownIt = require('markdown-it');
+import Token = require('markdown-it/lib/token');
+import State = require('markdown-it/lib/rules_core/state_core');
 
 declare namespace anchor {
   export type RenderHref = (slug: string, state: State) => string;
@@ -62,4 +62,4 @@ declare namespace anchor {
 
 declare function anchor(md: MarkdownIt, opts?: anchor.AnchorOptions): void;
 
-export = anchor;
+export default anchor;


### PR DESCRIPTION
The current type-declarations of `markdown-it-anchor` are incorrect.
Thus, this module can only be consumed if `esModuleInterop` is set to `true` in the project which tries to consume `markdown-it-anchor`.

This PR changes the type-declarations properly.

All, `markdown-it`, `markdown-it/lib/token` and `markdown-it/lib/rules_core/state_core` use a `module.exports = [...]`-statement rather than a `export default [,,,]`-statement.

However, as seen here, the imports are written as if a `export default [...]`-module is being imported:
https://github.com/valeriangalliat/markdown-it-anchor/blob/55928244bb98e77fd98885d3840cb16c3ed6c085/types/index.d.ts#L1-L3

Therefore, these import-statements need to be changed to `import x = require("module-x");`.

What's more, the `markdown-it-anchor`-module uses an `export default x`-statement rather than a `module.exports = x`-statement.
However, the type-declaration suggests that the module is a `module.exports = x`-module:
https://github.com/valeriangalliat/markdown-it-anchor/blob/55928244bb98e77fd98885d3840cb16c3ed6c085/types/index.d.ts#L65

In order to fix this, I changed this statement to `export default anchor;`.

Also I added `@types/markdown-it` to the `dependencies` as the type-declarations depend on it.
Optionally you could add it to `peerDependencies` but I'm not quite sure whether that's the right way to got, tbh.

I'd love to see this implemented in a new patch-version as soon as possible.
Please note, that this change was taken from the previous type-declaration available on `DefinitelyTyped`:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/9c1e78c99106fc3e1be574ca1b968d01963e032d/types/markdown-it-anchor/index.d.ts