### PR TITLE
Make permalink functions' opts arg optional

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,7 +14,7 @@ declare namespace anchor {
   }
 
   export interface HeaderLinkPermalinkOptions extends PermalinkOptions {
-    safariReaderFix: boolean;
+    safariReaderFix?: boolean;
   }
 
   export interface LinkAfterHeaderPermalinkOptions extends PermalinkOptions {
@@ -58,10 +58,10 @@ declare namespace anchor {
   }
 
   export const permalink: {
-    headerLink: (opts: HeaderLinkPermalinkOptions) => PermalinkGenerator
-    linkAfterHeader: (opts: LinkAfterHeaderPermalinkOptions) => PermalinkGenerator
-    linkInsideHeader: (opts: LinkInsideHeaderPermalinkOptions) => PermalinkGenerator
-    ariaHidden: (opts: AriaHiddenPermalinkOptions) => PermalinkGenerator
+    headerLink: (opts?: HeaderLinkPermalinkOptions) => PermalinkGenerator
+    linkAfterHeader: (opts?: LinkAfterHeaderPermalinkOptions) => PermalinkGenerator
+    linkInsideHeader: (opts?: LinkInsideHeaderPermalinkOptions) => PermalinkGenerator
+    ariaHidden: (opts?: AriaHiddenPermalinkOptions) => PermalinkGenerator
   };
 }
 


### PR DESCRIPTION
The new `safariReaderFix` opt for `headerLink` and the `opts` arg itself for all permalink functions are required in the types. It does not look like that matches reality in the implementation as defaults are applied to these. This changes the types definition to mark all of these as optional.

If this does not appear to be the case, then the `headerLink` section of the README should be updated to remove the `headerLink()` example shown without an opts arg.

I'm not sure what appropriate contribution guidelines are or if there are specific tests to run so largely looking for feedback on if this is a reasonable change and if there are any quality checks I need to perform.