### PR TITLE
Pass env to `slugify`

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function anchor (md, opts) {
       let slug = token.attrGet('id')
 
       if (slug == null) {
-        slug = uniqueSlug(opts.slugify(title), slugs, false, opts.uniqueSlugStartIndex)
+        slug = uniqueSlug(opts.slugify(title, state.env), slugs, false, opts.uniqueSlugStartIndex)
       } else {
         slug = uniqueSlug(slug, slugs, true, opts.uniqueSlugStartIndex)
       }

--- a/test.js
+++ b/test.js
@@ -232,6 +232,13 @@ test('getTokensText', t => {
   )
 })
 
+test('slugify', t => {
+	t.is(
+		md().use(anchor, { slugify: (title, env) => `${env.docId}-${title}` }).render('# bar', { docId: 'foo' }),
+		'<h1 id="foo-bar" tabindex="-1">bar</h1>\n'
+	)
+})
+
 nest('permalink.linkInsideHeader', test => {
   test('default', t => {
     t.is(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -47,7 +47,7 @@ declare namespace anchor {
   export interface AnchorOptions {
     level?: number | number[];
 
-    slugify?(str: string): string;
+    slugify?(str: string, env: any): string;
     getTokensText?(tokens: Token[]): string;
 
     uniqueSlugStartIndex?: number;


### PR DESCRIPTION
Make it possible to prefix slugs differently in each render