### PR TITLE
fix: fix markdown-it types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import MarkdownIt = require('markdown-it');
+import MarkdownIt from 'markdown-it';
 import Token from 'markdown-it/lib/token.mjs';
 import State from 'markdown-it/lib/rules_core/state_core.mjs';
 


### PR DESCRIPTION
This PR fixes the error:

```
types/index.d.ts:69:29 - error TS2709: Cannot use namespace 'MarkdownIt' as a type.

69 declare function anchor(md: MarkdownIt, opts?: anchor.AnchorOptions): void;
```