### PR TITLE
Export Token and State types from index.d.ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,8 +1,10 @@
 import MarkdownIt from 'markdown-it';
-import Token from 'markdown-it/lib/token.mjs';
-import State from 'markdown-it/lib/rules_core/state_core.mjs';
+import Token as JSToken from 'markdown-it/lib/token.mjs';
+import State as JSState from 'markdown-it/lib/rules_core/state_core.mjs';
 
 declare namespace anchor {
+  export type Token = JSToken;
+  export type State = JSState;
   export type RenderHref = (slug: string, state: State) => string;
   export type RenderAttrs = (slug: string, state: State) => Record<string, string | number>;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,12 +1,8 @@
-import MarkdownIt from 'markdown-it';
-import Token as JSToken from 'markdown-it/lib/token.mjs';
-import State as JSState from 'markdown-it/lib/rules_core/state_core.mjs';
+import MarkdownIt, {StateCore, Token} from 'markdown-it';
 
 declare namespace anchor {
-  export type Token = JSToken;
-  export type State = JSState;
-  export type RenderHref = (slug: string, state: State) => string;
-  export type RenderAttrs = (slug: string, state: State) => Record<string, string | number>;
+  export type RenderHref = (slug: string, state: StateCore) => string;
+  export type RenderAttrs = (slug: string, state: StateCore) => Record<string, string | number>;
 
   export interface PermalinkOptions {
     class?: string,
@@ -39,7 +35,7 @@ declare namespace anchor {
     placement?: 'before' | 'after'
   }
 
-  export type PermalinkGenerator = (slug: string, opts: PermalinkOptions, state: State, index: number) => void;
+  export type PermalinkGenerator = (slug: string, opts: PermalinkOptions, state: StateCore, index: number) => void;
 
   export interface AnchorInfo {
     slug: string;
@@ -50,7 +46,7 @@ declare namespace anchor {
     level?: number | number[];
 
     slugify?(str: string): string;
-    slugifyWithState?(str: string, state: State): string;
+    slugifyWithStateCore?(str: string, state: StateCore): string;
     getTokensText?(tokens: Token[]): string;
 
     uniqueSlugStartIndex?: number;


### PR DESCRIPTION
This makes it possible to accurately declare callback functions that take these types.